### PR TITLE
fix: arrow buttons not showing on mobile

### DIFF
--- a/app/client/components/ui/WordHistory.tsx
+++ b/app/client/components/ui/WordHistory.tsx
@@ -155,7 +155,7 @@ function WordHistory({
                 }
               }}
               className="pr-3"
-            > ←
+            >
               <Icon icon="arrowLeft" title="arrow left" />
             </button>
             <h2>Guesses for Row {currentRow + enteredWordsIndexOffset + 1}</h2>{" "}
@@ -166,7 +166,7 @@ function WordHistory({
                 }
               }}
               className="rotate-180 pr-3"
-            > ←
+            >
               <Icon icon="arrowLeft" title="arrow right" />
             </button>
           </div>

--- a/app/client/components/utils/other/Icon.tsx
+++ b/app/client/components/utils/other/Icon.tsx
@@ -222,6 +222,9 @@ const ArrowLeftIcon = () => (
     viewBox="0 0 24 24"
     aria-hidden="true"
     focusable="false"
+    width="24"
+    height="24"
+    fill="currentColor"
   >
     <path d="M17.77 3.77L16 2 6 12l10 10 1.77-1.77L9.54 12z" />
   </svg>


### PR DESCRIPTION
-Add fixed width and height to arrow icon so that it renders correctly on mobile browsers.

-Remove placeholder arrows used to debug this issue.