### PR TITLE
fix: PostHog errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ setup_droplet.txt
 config.env
 *.env
 database.sql
+ecosystem.config.json
 
 

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -5,19 +5,35 @@ import { posthog } from "posthog-js";
 
 function PosthogInit() {
   useEffect(() => {
-    if (typeof window !== "undefined" && "requestIdleCallback" in window) {
-      requestIdleCallback(() => {
+    try {
+      if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+        requestIdleCallback(() => {
+          posthog.init("phc_2IQDpa7YpxYMhcOXtPMlgcrrHmNjX4pY3wuvr3LKjS3", {
+            api_host: "https://us.i.posthog.com",
+            person_profiles: "identified_only", // or 'always' for anonymous users
+          });
+        });
+      } else {
         posthog.init("phc_2IQDpa7YpxYMhcOXtPMlgcrrHmNjX4pY3wuvr3LKjS3", {
           api_host: "https://us.i.posthog.com",
-          person_profiles: "identified_only", // or 'always' for anonymous users
+          person_profiles: "identified_only",
         });
-      });
-    } else {
-      // Fallback if requestIdleCallback is not supported
-      posthog.init("phc_2IQDpa7YpxYMhcOXtPMlgcrrHmNjX4pY3wuvr3LKjS3", {
-        api_host: "https://us.i.posthog.com",
-        person_profiles: "identified_only",
-      });
+      }
+    } catch (error: unknown) {
+      // Check if the error is an instance of Error
+      if (error instanceof Error) {
+        // Suppress specific error messages
+        if (
+          error.message.includes("CSP") ||
+          error.message.includes("inline script")
+        ) {
+          // Do nothing
+        } else {
+          console.error(error); // Log other errors
+        }
+      } else {
+        console.error("An unknown error occurred:", error);
+      }
     }
   }, []);
 


### PR DESCRIPTION
-Handle CSP error thrown by PostHog so that it isn't displayed in console unnecessairly.