### PR TITLE
fix: PostHog errors

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -24,8 +24,8 @@ function PosthogInit() {
       if (error instanceof Error) {
         // Suppress specific error messages
         if (
-          error.message.includes("CSP") ||
-          error.message.includes("inline script")
+          error.message.includes("Content Security Policy") ||
+          error.message.includes("script-src") || error.message.includes("nonce")
         ) {
           // Do nothing
         } else {


### PR DESCRIPTION
-Handle CSP error thrown by PostHog so that it isn't displayed in console unnecessairly.